### PR TITLE
Supporting CSS modules :export block

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,10 +54,18 @@ module.exports = postcss.plugin('postcss-react-native', function (opts) {
         const root = {
             rules: [ro],
             namespaces: {},
-            imports: []
+            imports: [],
+            exports: {}
         };
         const walker = createWalker(ro);
         src.walkRules((rule)=> {
+            if (rule.selector === ':export') {
+                rule.walkDecls(function (decl) {
+                    root.exports[decl.prop] = decl.value;
+                });
+                rule.remove();
+                return;
+            }
             if (rule.parent.type !== 'root') {
                 return;
             }

--- a/src/source.js
+++ b/src/source.js
@@ -215,6 +215,11 @@ export const writeImports = (imports = []) => {
 `;
 };
 
+export const writeExports = (exportsObj = {}) => {
+    return Object.keys(exportsObj).map(
+      key => `exports['${key}'] = '${exportsObj[key]}';`).join('\n');
+};
+
 export const rulesAreEqual = (ruleA, ruleB) => {
     const ruleAProps = Object.keys(ruleA);
     const ruleBProps = Object.keys(ruleB);
@@ -285,6 +290,9 @@ export const source = (model)=> {
 
      //imports
      ${writeImports(model.imports)}
+     
+     //exports
+     ${writeExports(model.exports)}
     
      //internals
      exports.internals = function(_internals){

--- a/test/fixtures/clazz.css.json
+++ b/test/fixtures/clazz.css.json
@@ -179,5 +179,6 @@
   "namespaces": {
     "View": "react-native.View"
   },
-  "imports": []
+  "imports": [],
+  "exports": {}
 }

--- a/test/fixtures/exports.css
+++ b/test/fixtures/exports.css
@@ -1,0 +1,7 @@
+:export {
+    color: #FF0000;
+}
+
+.other {
+    opacity: 0.5;
+}

--- a/test/postcss-react-native-test.js
+++ b/test/postcss-react-native-test.js
@@ -66,7 +66,8 @@ describe('postcss-react-native', function () {
                         }
                     ],
                     "namespaces": {},
-                    "imports": []
+                    "imports": [],
+                    "exports": {}
                 });
             },
             toStyleSheet(json, input){
@@ -217,4 +218,15 @@ describe('postcss-react-native', function () {
         });
     });
 
+    it('should parse :export selector', function () {
+        return test('exports', (f, source) => {
+            const css = f({height: 1024, width: 768, scale: 1}, 'android');
+            expect(css.color).to.eql('#FF0000');
+            expect(css.default).to.eql({
+                "other": {
+                    "opacity": 0.5
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
Not sure if this is useful for everyone, but this PR adds to support to `:export` block, part of CSS Modules ICSS spec - https://github.com/css-modules/icss#export

Basically it allows you export CSS symbols to JS, like:
```
:export {
  color: #FF0000;
  whatever: 'xxx'
}
```
