### PR TITLE
Avoid undefined values on StyleSheet

### DIFF
--- a/src/source.js
+++ b/src/source.js
@@ -313,7 +313,10 @@ export const source = (model)=> {
        (config)=>{
          const internals = exports.internals(importedInternals);
          return StyleSheet.create(Object.keys(internals).reduce((ret,internal)=>{
-           ret[internal] = internals[internal](config).__style;
+           const value = internals[internal](config).__style;
+           if (typeof (value) !== 'undefined') {
+             ret[internal] = value;
+           }
            return ret;
          }, {}));
      }));


### PR DESCRIPTION
Only noticed this behavior on Android - but if for some reason, parser returns `undefined`
values for an attribute (like a non-supported selector, such as `:after` and `:before`), React Native
will throw an error inside `StyleSheet.create` saying `Object.freeze` can only be used with objects. On iOS,
this error does not occur.

Ideally this fix would make sure we never get `undefined` values at this point, but here's a quick fix
that will avoid this error.