### PR TITLE
Avoid empty if statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "postcss-react-native",
-  "version": "1.0.1",
+  "name": "@loggi/postcss-react-native",
+  "version": "1.1.0-alpha.1",
   "description": "PostCSS plugin to create react stylesheets",
   "keywords": [
     "postcss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/postcss-react-native",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0",
   "description": "PostCSS plugin to create react stylesheets",
   "keywords": [
     "postcss",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "react-native-animatable": "^0.6.1"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.9.0",
+    "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react-native": "^1.9.1",
     "babel-register": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
     "fb-watchman": "^1.9.0",
     "lodash": "^3.10.1",
     "mocha": "^2.2.5"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "prop-types": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/postcss-react-native",
-  "version": "1.1.0-alpha.1",
+  "version": "2.0.0-alpha.1",
   "description": "PostCSS plugin to create react stylesheets",
   "keywords": [
     "postcss",

--- a/src/AnimatedCSS.js
+++ b/src/AnimatedCSS.js
@@ -1,7 +1,8 @@
 import React, {
     Component,
-    PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import  {
     Animated,

--- a/src/DimensionComponent.js
+++ b/src/DimensionComponent.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {PropTypes} from 'prop-types';
+import PropTypes from 'prop-types';
 import {View, Dimensions, PixelRatio, Platform} from 'react-native';
 import {calculate, asArray, splitClass, splitComma, toggle, WINDOW, window} from './componentHelpers';
 import listen from './listen';

--- a/src/DimensionComponent.js
+++ b/src/DimensionComponent.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import {PropTypes} from 'prop-types';
 import {View, Dimensions, PixelRatio, Platform} from 'react-native';
 import {calculate, asArray, splitClass, splitComma, toggle, WINDOW, window} from './componentHelpers';
 import listen from './listen';

--- a/src/decls.js
+++ b/src/decls.js
@@ -93,10 +93,10 @@ export const HANDLERS = Object.assign({}, DECLS, {
             case 'wrap':
                 return enumer('wrap',
                     'nowrap')(postfix, value);
+            case 'basis':
+                return postfixWrap(postfix, value.replace('%', '%%'));
             case 'grow':
             case 'shrink':
-            case 'basis':
-
         }
         return {
             ['']: value

--- a/src/source.js
+++ b/src/source.js
@@ -95,7 +95,6 @@ const pdecl = (root, type, values) => {
 };
 
 const writeRule = ({css, expressions = []}) => {
-
     const src = Object.keys(css).map((key)=> {
 
         const decls = css[key];
@@ -134,8 +133,12 @@ const writeExpressions = ({expressions, inverse})=> {
 
 const writeSheet = (cssStr, expressions = []) => {
     if (expressions.length) {
+        const conditionals = expressions.map(writeExpressions).filter(c => c !== '');
+        if (conditionals.length === 0) {
+            return '';
+        }
         return `
-          if (${expressions.map(writeExpressions).join(' || ')}){\n${cssStr}\n}
+          if (${conditionals.join(' || ')}){\n${cssStr}\n}
           `;
     } else {
         return `
@@ -313,7 +316,10 @@ export const source = (model)=> {
        (config)=>{
          const internals = exports.internals(importedInternals);
          return StyleSheet.create(Object.keys(internals).reduce((ret,internal)=>{
-           ret[internal] = internals[internal](config).__style;
+           const value = internals[internal](config).__style;
+           if (typeof (value) !== 'undefined') {
+             ret[internal] = value;
+           }
            return ret;
          }, {}));
      }));

--- a/src/source.js
+++ b/src/source.js
@@ -18,6 +18,8 @@ const rhsunit = (u)=> {
     if (un && typeof un.value === 'number') {
         if (un.unit == 'deg') {
             ret = `'${un.value} deg'`
+        } else if (un.unit === '%%') {
+            ret = `'${un.value}%'`;
         } else {
             ret = un.unit ? `(${un.value} * units["${un.unit}"])` : un.value;
         }


### PR DESCRIPTION
When you have non-supported rules, such as `@media print`, you could
end up with empty `if ()` statements. This fix makes sure we only
write if statements when we have valid conditionals.